### PR TITLE
macOS support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
 
 dependencies = [
     "asyncinotify>=4.2.0",
+    "pyobjc; platform_system=='Darwin'",
 ]
 urls."Bug Tracker" = "https://github.com/bluetooth-devices/aiousbwatcher/issues"
 urls.Changelog = "https://github.com/bluetooth-devices/aiousbwatcher/blob/main/CHANGELOG.md"

--- a/src/aiousbwatcher/macos.py
+++ b/src/aiousbwatcher/macos.py
@@ -1,0 +1,143 @@
+import asyncio
+import enum
+import threading
+import warnings
+from typing import Self
+
+import objc
+from CoreFoundation import (
+    CFRunLoopAddSource,
+    CFRunLoopGetCurrent,
+    CFRunLoopRun,
+    CFRunLoopStop,
+    kCFRunLoopDefaultMode,
+)
+
+from .macos_types import (
+    IOIteratorNext,
+    IONotificationPortCreate,
+    IONotificationPortGetRunLoopSource,
+    IOObjectRelease,
+    IOServiceAddMatchingNotification,
+    IOServiceMatching,
+    kIOMasterPortDefault,
+    kIOMatchedNotification,
+    kIOTerminatedNotification,
+    kIOUSBDeviceClassName,
+)
+
+
+def _consume_iterator(io_iterator):
+    """Required to "arm" the io_iterator for future notifications."""
+    while True:
+        obj = IOIteratorNext(io_iterator)
+        if not obj:
+            break
+
+        IOObjectRelease(obj)
+
+
+class MacosUsbEvent(enum.Enum):
+    ADDED = "ADDED"
+    REMOVED = "REMOVED"
+
+
+class MacosUsbNotifier:
+    def __init__(self) -> None:
+        self._loop = None
+        self._cf_run_loop = None
+        self._queue = asyncio.Queue()
+        self._thread = None
+
+    async def __aenter__(self) -> Self:
+        self._loop = asyncio.get_running_loop()
+        self._thread = threading.Thread(target=self._cf_run_loop_thread)
+        self._thread.start()
+
+        print("Starting?")
+
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        if self._cf_run_loop is not None:
+            CFRunLoopStop(self._cf_run_loop)
+
+        if self._thread is not None:
+            self._thread.join()
+            self._thread = None
+
+    def __aiter__(self) -> Self:
+        return self
+
+    async def __anext__(self) -> MacosUsbEvent:
+        try:
+            return await self._queue.get()
+        except asyncio.CancelledError:
+            raise StopAsyncIteration
+
+    def _cf_run_loop_thread(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", objc.ObjCPointerWarning)
+            port = IONotificationPortCreate(kIOMasterPortDefault)
+
+        @objc.callbackFor(IOServiceAddMatchingNotification)
+        def device_added_callback(refCon, iterator):
+            _consume_iterator(iterator)
+            self._loop.call_soon_threadsafe(
+                self._queue.put_nowait,
+                MacosUsbEvent.ADDED,
+            )
+
+        @objc.callbackFor(IOServiceAddMatchingNotification)
+        def device_removed_callback(refCon, iterator):
+            _consume_iterator(iterator)
+            self._loop.call_soon_threadsafe(
+                self._queue.put_nowait,
+                MacosUsbEvent.REMOVED,
+            )
+
+        # Device add
+        _, add_iter = IOServiceAddMatchingNotification(
+            port,
+            kIOMatchedNotification,
+            IOServiceMatching(kIOUSBDeviceClassName),
+            device_added_callback,
+            0,  # refCon
+            None,
+        )
+        _consume_iterator(add_iter)
+
+        # Device remove
+        _, remove_iter = IOServiceAddMatchingNotification(
+            port,
+            kIOTerminatedNotification,
+            IOServiceMatching(kIOUSBDeviceClassName),
+            device_removed_callback,
+            0,  # refCon
+            None,
+        )
+        _consume_iterator(remove_iter)
+
+        # Add notification port to run loop
+        src = IONotificationPortGetRunLoopSource(port)
+        self._cf_run_loop = CFRunLoopGetCurrent()
+        CFRunLoopAddSource(self._cf_run_loop, src, kCFRunLoopDefaultMode)
+
+        # Run the CFRunLoop until stop
+        # installMachInterrupt()  # TODO: ctrl-c breaks without this but also with this
+        CFRunLoopRun()
+
+
+async def main():
+    while True:
+        async with MacosUsbNotifier() as notifier:
+            print("Waiting for USB events. Ctrl+C to exit.")
+            async for event in notifier:
+                print("Got USB event:", event)
+                break
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())

--- a/src/aiousbwatcher/macos_types.py
+++ b/src/aiousbwatcher/macos_types.py
@@ -1,0 +1,77 @@
+import objc
+from Foundation import NSBundle
+
+kIOMasterPortDefault = 0
+
+kIOUSBDeviceClassName = b"IOUSBDevice"
+
+kIOFirstPublishNotification = b"IOServiceFirstPublish"
+kIOPublishNotification = b"IOServicePublish"
+kIOMatchedNotification = b"IOServiceMatched"
+kIOFirstMatchNotification = b"IOServiceFirstMatch"
+kIOTerminatedNotification = b"IOServiceTerminate"
+
+
+objc.loadBundleFunctions(
+    bundle=NSBundle.bundleWithIdentifier_("com.apple.framework.IOKit"),
+    module_globals=globals(),
+    functionInfo=[
+        ("IOServiceMatching", b"^{__CFDictionary=}*"),
+        (
+            "IOServiceAddMatchingNotification",
+            b"i^{_IONotificationPort}*^{__CFDictionary=}^?^vo^I",
+            "",
+            {
+                "arguments": {
+                    3: {
+                        "callable": {
+                            "arguments": {
+                                0: {"type": b"^v"},
+                                1: {"type": b"I"},
+                            },
+                            "retval": {"type": b"v"},
+                        }
+                    }
+                }
+            },
+        ),
+        (
+            "IONotificationPortCreate",
+            b"^{_IONotificationPort}I",
+            "",
+            {
+                "arguments": {
+                    0: {"type": "I"},
+                },
+                "retval": {
+                    "already_retained": True,
+                },
+            },
+        ),
+        (
+            "IONotificationPortGetRunLoopSource",
+            b"^{__CFRunLoopSource=}^{_IONotificationPort}",
+        ),
+        ("IOIteratorNext", b"II"),
+        ("IOObjectRelease", b"II"),
+    ],
+    skip_undefined=False,
+)
+
+__all__ = [
+    # Injected into the scope by pyobjc
+    "IOServiceMatching",
+    "IOServiceAddMatchingNotification",
+    "IONotificationPortCreate",
+    "IONotificationPortGetRunLoopSource",
+    "IOIteratorNext",
+    "IOObjectRelease",
+    # Exported
+    "kIOMasterPortDefault",
+    "kIOFirstPublishNotification",
+    "kIOPublishNotification",
+    "kIOMatchedNotification",
+    "kIOFirstMatchNotification",
+    "kIOTerminatedNotification",
+    "kIOUSBDeviceClassName",
+]


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/bluetooth-devices/aiousbwatcher/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
I'm creating this PR to track the changes and will hopefully get back to it in the near future. If anyone else is interested in this feature, feel free to pick it up! Just leave a comment.

For now, the self-contained  implementation within `macos` runs. Huge thank you to https://github.com/meeuw/usb-plug-notification-darwin for the `IOIteratorNext` hint and the bundle function definitions!

TODO:

- Investigate why CTRL-C doesn't work reliably both with and without `installMachInterrupt()`
- Pare down dependencies to the minimum packages required for pyobjc.
- Abstract both implementations.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/bluetooth-devices/aiousbwatcher/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
