### PR TITLE
fix: avoid RuntimeError when a callback unregisters during firing

### DIFF
--- a/src/aiousbwatcher/impl.py
+++ b/src/aiousbwatcher/impl.py
@@ -102,7 +102,7 @@ class AIOUSBWatcher:
         self._callbacks.remove(callback)
 
     def _async_call_callbacks(self) -> None:
-        for callback in self._callbacks:
+        for callback in list(self._callbacks):
             try:
                 callback()
             except Exception as e:

--- a/tests/test_impl.py
+++ b/tests/test_impl.py
@@ -81,6 +81,26 @@ async def test_aiousbwatcher_broken_callbacks(
 
 
 @pytest.mark.asyncio
+async def test_aiousbwatcher_callback_unregisters_during_fire() -> None:
+    watcher = AIOUSBWatcher()
+    fired: list[str] = []
+
+    def first() -> None:
+        fired.append("first")
+        unregister_first()
+
+    def second() -> None:
+        fired.append("second")
+
+    unregister_first = watcher.async_register_callback(first)
+    watcher.async_register_callback(second)
+
+    watcher._async_call_callbacks()
+
+    assert sorted(fired) == ["first", "second"]
+
+
+@pytest.mark.asyncio
 @pytest.mark.skipif(
     platform != "linux", reason="Inotify not available on this platform"
 )


### PR DESCRIPTION
`_async_call_callbacks` iterates the live `self._callbacks` set, so a callback that calls its own unregister function while being invoked mutates the set mid-iteration and raises `RuntimeError: Set changed size during iteration`, which also skips the remaining callbacks for that event. Self-unregistering on the first event is a common pattern, so this is reachable in normal use. Iterating a snapshot fixes it. Closes #37.