### PR TITLE
fix: make watcher stop idempotent

### DIFF
--- a/src/aiousbwatcher/impl.py
+++ b/src/aiousbwatcher/impl.py
@@ -65,7 +65,8 @@ class AIOUSBWatcher:
 
     def _async_stop(self) -> None:
         """Stop the watcher."""
-        assert self._task is not None  # noqa
+        if self._task is None:
+            return
         self._task.cancel()
         self._task = None
 

--- a/tests/test_impl.py
+++ b/tests/test_impl.py
@@ -1,7 +1,7 @@
 import asyncio
 from pathlib import Path
 from sys import platform
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -91,6 +91,18 @@ async def test_aiousbwatcher_attempt_to_start_twice(tmp_path: Path) -> None:
         with pytest.raises(RuntimeError):
             watcher.async_start()
         stop()
+
+
+@pytest.mark.asyncio
+async def test_aiousbwatcher_stop_is_idempotent() -> None:
+    watcher = AIOUSBWatcher()
+    task = Mock()
+    watcher._task = task
+
+    watcher._async_stop()
+    watcher._async_stop()
+
+    task.cancel.assert_called_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #46.

## Summary
- make the returned stop callable idempotent by returning early when the watcher task is already cleared
- add a platform-independent regression test for calling stop twice

## Tests
- `uv run pytest tests/test_impl.py::test_aiousbwatcher_stop_is_idempotent -q`
- `uv run pytest tests/test_impl.py -q` (macOS: 2 passed, 4 skipped)
- `uv run ruff check src/aiousbwatcher/impl.py tests/test_impl.py`
- `git diff --check`
